### PR TITLE
add default handling for application shutdown & being kicked from the server.

### DIFF
--- a/examples/client_echo/main.go
+++ b/examples/client_echo/main.go
@@ -29,16 +29,11 @@ func main() {
 		return client.SendChat(msg.Message)
 	})
 
-	client.OnDisconnect(func(msg *messages7.CtrlClose, defaultAction teeworlds7.DefaultAction) error {
-		cancel() // close application when kicked from server
-		return nil
-	})
-
 	err := client.ConnectContext(ctx, "127.0.0.1", 8303)
 	if err != nil && !errors.Is(err, context.Canceled) {
-		fmt.Println("failed to connect:", err)
+		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	fmt.Println("shutdown")
+	fmt.Println("graceful shutdown")
 }

--- a/teeworlds7/client.go
+++ b/teeworlds7/client.go
@@ -1,6 +1,7 @@
 package teeworlds7
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -58,6 +59,13 @@ type Client struct {
 
 	// might be -1 if we do not know our own id yet
 	LocalClientId int
+
+	// cancelation & graceful shutdown handling
+	// These fields usually do not need to be accesse by the user
+	// They might only be needed whn you want to change the default behavio
+	// of the OnDisconnect callback
+	Ctx         context.Context
+	CancelCause context.CancelCauseFunc
 }
 
 // TODO: add this for all items and move it to a different file

--- a/teeworlds7/client.go
+++ b/teeworlds7/client.go
@@ -61,8 +61,8 @@ type Client struct {
 	LocalClientId int
 
 	// cancelation & graceful shutdown handling
-	// These fields usually do not need to be accesse by the user
-	// They might only be needed whn you want to change the default behavio
+	// These fields usually do not need to be accessed by the user
+	// They might only be needed in case you want to change the default behavior
 	// of the OnDisconnect callback
 	Ctx         context.Context
 	CancelCause context.CancelCauseFunc

--- a/teeworlds7/networking.go
+++ b/teeworlds7/networking.go
@@ -93,15 +93,9 @@ func (client *Client) ConnectContext(ctx context.Context, serverIp string, serve
 		if ctxErr := context.Cause(client.Ctx); ctxErr != nil && !errors.Is(ctxErr, context.Canceled) {
 			err = ctxErr
 		} else {
-			// send disconnect message to server before closing the connection.
-			reason := "connection closed"
-			if err != nil {
-				reason = fmt.Sprintf("connection closed: %v", err)
-			}
-
 			// send disconnect message to server in order not to
 			// occupy a slot on the server
-			disconnectErr := client.SendMessage(&messages7.CtrlClose{Reason: reason})
+			disconnectErr := client.SendMessage(&messages7.CtrlClose{})
 			if disconnectErr != nil {
 				slog.Error("failed to send disconnect message", "error", disconnectErr)
 			}

--- a/teeworlds7/networking.go
+++ b/teeworlds7/networking.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/teeworlds-go/protocol/messages7"
 	"github.com/teeworlds-go/protocol/network7"
 	"github.com/teeworlds-go/protocol/protocol7"
 )
@@ -68,8 +69,9 @@ func (client *Client) Connect(serverIp string, serverPort int) error {
 }
 
 func (client *Client) ConnectContext(ctx context.Context, serverIp string, serverPort int) (err error) {
-	ctx, cancelCause := context.WithCancelCause(ctx)
-	defer cancelCause(nil) // always cancel
+	// create a child context that we have ownership over.
+	client.Ctx, client.CancelCause = context.WithCancelCause(ctx)
+	defer client.CancelCause(nil) // always cancel
 
 	// wait for the reader goroutine to finish execution, before leaving this function scope
 	var wg sync.WaitGroup
@@ -77,7 +79,7 @@ func (client *Client) ConnectContext(ctx context.Context, serverIp string, serve
 
 	ch := make(chan []byte, maxPacksize)
 	var d net.Dialer
-	conn, err := d.DialContext(ctx, "udp", fmt.Sprintf("%s:%d", serverIp, serverPort))
+	conn, err := d.DialContext(client.Ctx, "udp", fmt.Sprintf("%s:%d", serverIp, serverPort))
 	if err != nil {
 		return fmt.Errorf("failed to connect to server: %s:%d: %w", serverIp, serverPort, err)
 	}
@@ -86,18 +88,23 @@ func (client *Client) ConnectContext(ctx context.Context, serverIp string, serve
 		// only the first cancelation cause is relevant
 		// subsequent cancelations will be ignored
 		// this one might be a subsequent cancelation
-		cancelCause(err)
+		client.CancelCause(err)
 
-		ctxErr := context.Cause(ctx)
-		if ctxErr != nil {
+		if ctxErr := context.Cause(client.Ctx); ctxErr != nil && !errors.Is(ctxErr, context.Canceled) {
 			err = ctxErr
-			return
-		}
+		} else {
+			// send disconnect message to server before closing the connection.
+			reason := "connection closed"
+			if err != nil {
+				reason = fmt.Sprintf("connection closed: %v", err)
+			}
 
-		ctxErr = ctx.Err()
-		if ctxErr != nil && !errors.Is(ctxErr, context.Canceled) {
-			err = ctxErr
-			return
+			// send disconnect message to server in order not to
+			// occupy a slot on the server
+			disconnectErr := client.SendMessage(&messages7.CtrlClose{Reason: reason})
+			if disconnectErr != nil {
+				slog.Error("failed to send disconnect message", "error", disconnectErr)
+			}
 		}
 
 		// close connection after error handling in order not to
@@ -112,7 +119,7 @@ func (client *Client) ConnectContext(ctx context.Context, serverIp string, serve
 	client.Game.Players = make([]Player, network7.MaxClients)
 
 	wg.Add(1)
-	go readNetwork(ctx, cancelCause, &wg, ch, conn)
+	go readNetwork(client.Ctx, client.CancelCause, &wg, ch, conn)
 
 	err = client.SendPacket(client.Session.CtrlToken())
 	if err != nil {
@@ -158,7 +165,7 @@ func (client *Client) ConnectContext(ctx context.Context, serverIp string, serve
 					return err
 				}
 			}
-		case <-ctx.Done():
+		case <-client.Ctx.Done():
 			return nil
 		}
 	}

--- a/teeworlds7/packet.go
+++ b/teeworlds7/packet.go
@@ -1,11 +1,18 @@
 package teeworlds7
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/teeworlds-go/protocol/messages7"
 	"github.com/teeworlds-go/protocol/network7"
 	"github.com/teeworlds-go/protocol/protocol7"
+)
+
+var (
+	// This error is set as cancel cause in case that we are disconnected from the server
+	// This makes the error tangible for the user
+	ErrDisconnected = errors.New("disconnected")
 )
 
 func printUnknownMessage(msg messages7.NetMessage, msgType string) {
@@ -87,6 +94,7 @@ func (client *Client) processPacket(packet *protocol7.Packet) (err error) {
 			})
 		case *messages7.CtrlClose:
 			err = userMsgCallback(client.Callbacks.CtrlClose, msg, func() error {
+				client.CancelCause(fmt.Errorf("%w: %s", ErrDisconnected, msg.Reason))
 				fmt.Printf("disconnected (%s)\n", msg.Reason)
 				return nil
 			})


### PR DESCRIPTION
- in case that the application is shut down, we properly send a control message for disconnecting
- in case that we are kicked from the server, our client context is closed and further processing from that server is stopped (you may try to reconnect afterwards)
